### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
 uvicorn
+pytest
 httpx
 watchfiles

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,45 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    # Sports activities
+    "Soccer Team": {
+        "description": "Join the school soccer team and compete in matches",
+        "schedule": "Tuesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 18,
+        "participants": ["alex@mergington.edu", "lucas@mergington.edu"]
+    },
+    "Basketball Club": {
+        "description": "Practice basketball skills and play friendly games",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["mia@mergington.edu", "noah@mergington.edu"]
+    },
+    # Artistic activities
+    "Art Workshop": {
+        "description": "Explore painting, drawing, and sculpture techniques",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["ava@mergington.edu", "liam@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Act, direct, and produce school plays and performances",
+        "schedule": "Mondays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["ella@mergington.edu", "jack@mergington.edu"]
+    },
+    # Intellectual activities
+    "Math Olympiad": {
+        "description": "Prepare for math competitions and solve challenging problems",
+        "schedule": "Fridays, 2:00 PM - 3:30 PM",
+        "max_participants": 10,
+        "participants": ["grace@mergington.edu", "henry@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Conduct experiments and explore scientific concepts",
+        "schedule": "Tuesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 14,
+        "participants": ["chloe@mergington.edu", "ben@mergington.edu"]
     }
 }
 
@@ -61,6 +100,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up")
 
     # Add student
     activity["participants"].append(email)

--- a/src/app.py
+++ b/src/app.py
@@ -105,6 +105,9 @@ def signup_for_activity(activity_name: str, email: str):
     if email in activity["participants"]:
         raise HTTPException(status_code=400, detail="Student already signed up")
 
+    # Validate activity capacity has not been reached
+    if len(activity["participants"]) >= activity["max_participants"]:
+        raise HTTPException(status_code=400, detail="Activity is full")
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -108,3 +108,19 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+@app.post("/activities/{activity_name}/unregister")
+def unregister_participant(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    # Validate participant exists
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Participant not found in activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Removed {email} from {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -20,15 +20,70 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
-        activityCard.innerHTML = `
-          <h4>${name}</h4>
-          <p>${details.description}</p>
-          <p><strong>Schedule:</strong> ${details.schedule}</p>
-          <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
-        `;
+          activityCard.innerHTML = `
+            <h4>${name}</h4>
+            <p>${details.description}</p>
+            <p><strong>Schedule:</strong> ${details.schedule}</p>
+            <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+            <div class="participants-section">
+              <strong>Participants:</strong>
+              ${details.participants.length === 0
+                ? '<p class="no-participants">No participants yet.</p>'
+                : `<ul class="participants-list">
+                    ${details.participants
+                      .map(email => `
+                        <li class="participant-item">
+                          <span class="participant-email">${email}</span>
+                          <button class="delete-participant" title="Remove participant" data-activity="${name}" data-email="${email}">
+                            <span class="delete-icon">&#128465;</span>
+                          </button>
+                        </li>
+                      `)
+                      .join('')}
+                  </ul>`}
+            </div>
+          `;
 
         activitiesList.appendChild(activityCard);
 
+          // Add delete event listeners for participants
+          const deleteButtons = activityCard.querySelectorAll(".delete-participant");
+          deleteButtons.forEach(btn => {
+            btn.addEventListener("click", async (e) => {
+              e.preventDefault();
+              const activityName = btn.getAttribute("data-activity");
+              const participantEmail = btn.getAttribute("data-email");
+              try {
+                const response = await fetch(
+                  `/activities/${encodeURIComponent(activityName)}/unregister?email=${encodeURIComponent(participantEmail)}`,
+                  {
+                    method: "POST",
+                  }
+                );
+                const result = await response.json();
+                if (response.ok) {
+                  messageDiv.textContent = result.message || "Participant removed.";
+                  messageDiv.className = "success";
+                } else {
+                  messageDiv.textContent = result.detail || "Failed to remove participant.";
+                  messageDiv.className = "error";
+                }
+                messageDiv.classList.remove("hidden");
+                setTimeout(() => {
+                  messageDiv.classList.add("hidden");
+                }, 5000);
+                // Refresh activities list
+                fetchActivities();
+              } catch (error) {
+                messageDiv.textContent = "Error removing participant.";
+                messageDiv.className = "error";
+                messageDiv.classList.remove("hidden");
+                setTimeout(() => {
+                  messageDiv.classList.add("hidden");
+                }, 5000);
+              }
+            });
+          });
         // Add option to select dropdown
         const option = document.createElement("option");
         option.value = name;
@@ -62,6 +117,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        fetchActivities(); // Refresh activities list
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -20,30 +20,75 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
-          activityCard.innerHTML = `
-            <h4>${name}</h4>
-            <p>${details.description}</p>
-            <p><strong>Schedule:</strong> ${details.schedule}</p>
-            <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
-            <div class="participants-section">
-              <strong>Participants:</strong>
-              ${details.participants.length === 0
-                ? '<p class="no-participants">No participants yet.</p>'
-                : `<ul class="participants-list">
-                    ${details.participants
-                      .map(email => `
-                        <li class="participant-item">
-                          <span class="participant-email">${email}</span>
-                          <button class="delete-participant" title="Remove participant" data-activity="${name}" data-email="${email}">
-                            <span class="delete-icon">&#128465;</span>
-                          </button>
-                        </li>
-                      `)
-                      .join('')}
-                  </ul>`}
-            </div>
-          `;
+        // Build activity card content safely without using innerHTML
+        const titleEl = document.createElement("h4");
+        titleEl.textContent = name;
+        activityCard.appendChild(titleEl);
 
+        const descriptionEl = document.createElement("p");
+        descriptionEl.textContent = details.description;
+        activityCard.appendChild(descriptionEl);
+
+        const scheduleEl = document.createElement("p");
+        const scheduleStrong = document.createElement("strong");
+        scheduleStrong.textContent = "Schedule:";
+        scheduleEl.appendChild(scheduleStrong);
+        scheduleEl.appendChild(document.createTextNode(" " + details.schedule));
+        activityCard.appendChild(scheduleEl);
+
+        const availabilityEl = document.createElement("p");
+        const availabilityStrong = document.createElement("strong");
+        availabilityStrong.textContent = "Availability:";
+        availabilityEl.appendChild(availabilityStrong);
+        availabilityEl.appendChild(
+          document.createTextNode(" " + spotsLeft + " spots left")
+        );
+        activityCard.appendChild(availabilityEl);
+
+        const participantsSection = document.createElement("div");
+        participantsSection.className = "participants-section";
+
+        const participantsLabel = document.createElement("strong");
+        participantsLabel.textContent = "Participants:";
+        participantsSection.appendChild(participantsLabel);
+
+        if (details.participants.length === 0) {
+          const noParticipants = document.createElement("p");
+          noParticipants.className = "no-participants";
+          noParticipants.textContent = "No participants yet.";
+          participantsSection.appendChild(noParticipants);
+        } else {
+          const participantsListEl = document.createElement("ul");
+          participantsListEl.className = "participants-list";
+
+          details.participants.forEach((email) => {
+            const participantItem = document.createElement("li");
+            participantItem.className = "participant-item";
+
+            const emailSpan = document.createElement("span");
+            emailSpan.className = "participant-email";
+            emailSpan.textContent = email;
+            participantItem.appendChild(emailSpan);
+
+            const deleteButton = document.createElement("button");
+            deleteButton.className = "delete-participant";
+            deleteButton.title = "Remove participant";
+            deleteButton.setAttribute("data-activity", name);
+            deleteButton.setAttribute("data-email", email);
+
+            const deleteIconSpan = document.createElement("span");
+            deleteIconSpan.className = "delete-icon";
+            deleteIconSpan.textContent = "🗑️";
+            deleteButton.appendChild(deleteIconSpan);
+
+            participantItem.appendChild(deleteButton);
+            participantsListEl.appendChild(participantItem);
+          });
+
+          participantsSection.appendChild(participantsListEl);
+        }
+
+        activityCard.appendChild(participantsSection);
         activitiesList.appendChild(activityCard);
 
           // Add delete event listeners for participants

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -60,7 +60,13 @@ document.addEventListener("DOMContentLoaded", () => {
                     method: "POST",
                   }
                 );
-                const result = await response.json();
+                let result;
+                try {
+                  result = await response.json();
+                } catch (parseError) {
+                  console.error("Failed to parse unregister response as JSON:", parseError);
+                  result = {};
+                }
                 if (response.ok) {
                   messageDiv.textContent = result.message || "Participant removed.";
                   messageDiv.className = "success";

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -63,6 +63,7 @@ section h3 {
   border: 1px solid #ddd;
   border-radius: 5px;
   background-color: #f9f9f9;
+  box-shadow: 0 4px 12px rgba(0, 102, 204, 0.08);
 }
 
 .activity-card h4 {
@@ -72,6 +73,68 @@ section h3 {
 
 .activity-card p {
   margin-bottom: 8px;
+}
+
+.participants-section {
+  margin-top: 12px;
+  padding: 10px;
+  background-color: #eef6ff;
+  border-radius: 4px;
+  border: 1px solid #b3d1ff;
+}
+
+.participants-section strong {
+  color: #0066cc;
+  font-size: 15px;
+}
+
+
+.participants-list {
+  margin: 8px 0 0 0;
+  padding-left: 0;
+  list-style: none;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 4px;
+  color: #333;
+  font-size: 14px;
+  background: #fff;
+  border-radius: 3px;
+  padding: 3px 0;
+}
+
+.participant-email {
+  flex: 1;
+  padding-left: 4px;
+}
+
+.delete-participant {
+  background: none;
+  border: none;
+  cursor: pointer;
+  margin-left: 8px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  transition: background 0.2s;
+}
+
+.delete-participant:hover {
+  background: #ffebee;
+}
+
+.delete-icon {
+  color: #c62828;
+  font-size: 18px;
+  vertical-align: middle;
+}
+
+.no-participants {
+  color: #888;
+  font-style: italic;
+  margin: 8px 0 0 0;
 }
 
 .form-group {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from fastapi.testclient import TestClient
+from src.app import app
+
+@pytest.fixture
+def client():
+    return TestClient(app)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,11 @@
 import pytest
 from fastapi.testclient import TestClient
-from src.app import app
+from src.app import app, activities
 
 @pytest.fixture
 def client():
-    return TestClient(app)
+    original_activities = activities.copy()
+    with TestClient(app) as test_client:
+        yield test_client
+    activities.clear()
+    activities.update(original_activities)

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -1,0 +1,27 @@
+def test_signup_success(client):
+    # Arrange
+    activity = "Chess Club"
+    email = "newstudent@mergington.edu"
+    url = f"/activities/{activity}/signup?email={email}"
+
+    # Act
+    response = client.post(url)
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json()["message"] == f"Signed up {email} for {activity}"
+    assert email in client.get("/activities").json()[activity]["participants"]
+
+
+def test_signup_duplicate(client):
+    # Arrange
+    activity = "Chess Club"
+    email = "michael@mergington.edu"  # Already signed up
+    url = f"/activities/{activity}/signup?email={email}"
+
+    # Act
+    response = client.post(url)
+
+    # Assert
+    assert response.status_code == 400
+    assert "already signed up" in response.json()["detail"]

--- a/tests/test_unregister.py
+++ b/tests/test_unregister.py
@@ -25,3 +25,17 @@ def test_unregister_not_found(client):
     # Assert
     assert response.status_code == 404
     assert "Participant not found" in response.json()["detail"]
+
+
+def test_unregister_activity_not_found(client):
+    # Arrange
+    activity = "Nonexistent Activity"
+    email = "michael@mergington.edu"
+    url = f"/activities/{activity}/unregister?email={email}"
+
+    # Act
+    response = client.post(url)
+
+    # Assert
+    assert response.status_code == 404
+    assert "Activity not found" in response.json()["detail"]

--- a/tests/test_unregister.py
+++ b/tests/test_unregister.py
@@ -1,0 +1,27 @@
+def test_unregister_success(client):
+    # Arrange
+    activity = "Chess Club"
+    email = "michael@mergington.edu"
+    url = f"/activities/{activity}/unregister?email={email}"
+
+    # Act
+    response = client.post(url)
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json()["message"] == f"Removed {email} from {activity}"
+    assert email not in client.get("/activities").json()[activity]["participants"]
+
+
+def test_unregister_not_found(client):
+    # Arrange
+    activity = "Chess Club"
+    email = "notfound@mergington.edu"
+    url = f"/activities/{activity}/unregister?email={email}"
+
+    # Act
+    response = client.post(url)
+
+    # Assert
+    assert response.status_code == 404
+    assert "Participant not found" in response.json()["detail"]


### PR DESCRIPTION
This pull request adds new features and improvements to the school activities platform, focusing on participant management, user interface enhancements, and test coverage. The most important changes are grouped below by theme.

**Feature additions and participant management:**

* Added several new activities to the `activities` data structure in `src/app.py`, including sports, artistic, and intellectual clubs, each with their own schedules and participants.
* Implemented participant removal functionality with a new `/activities/{activity_name}/unregister` endpoint, allowing students to unregister from activities. Also added validation to prevent duplicate signups and ensure participant existence before removal.

**Frontend improvements:**

* Enhanced the activities UI in `src/static/app.js` to display participants for each activity, including a delete button for each participant. Added logic to handle participant removal via the new backend endpoint and refresh the activities list after changes. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R28-R86) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R120)
* Improved participant section styling in `src/static/styles.css`, including new styles for participant lists, delete buttons, and empty states. [[1]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R66) [[2]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R78-R139)

**Testing and quality assurance:**

* Added new tests for signup and unregister functionality in `tests/test_signup.py` and `tests/test_unregister.py`, covering success and error cases. Introduced a `client` fixture in `tests/conftest.py` for consistent test setup. [[1]](diffhunk://#diff-61ec098b3ee112a73dd8fad6565ff42d7189664d993b15b6e07d6ae5c718501eR1-R27) [[2]](diffhunk://#diff-21ccd8203cab33acf5126429131ad0a82f90f5710a8dd086d8974da3fb420462R1-R27) [[3]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R1-R7)